### PR TITLE
Revert multi line string

### DIFF
--- a/src/yaml.c
+++ b/src/yaml.c
@@ -370,7 +370,7 @@ int value_to_node(mrb_state *mrb,
         /* match \n except blank line at the end of string
          * https://github.com/ruby/psych/blob/v3.1.0/lib/psych/visitors/yaml_tree.rb#L299 */
         style = YAML_LITERAL_SCALAR_STYLE;
-      } else if (!isalnum(RSTRING_PTR(value)[0]) && strchr(RSTRING_PTR(value), '"') == NULL) {
+      } else if (!isalnum(RSTRING_PTR(value)[0])) {
         /* Easy mimic of https://github.com/ruby/psych/blob/v3.1.0/lib/psych/visitors/yaml_tree.rb#L307-L308 */
         style = YAML_DOUBLE_QUOTED_SCALAR_STYLE;
       }

--- a/src/yaml.c
+++ b/src/yaml.c
@@ -360,17 +360,12 @@ int value_to_node(mrb_state *mrb,
     {
       yaml_scalar_style_t style = YAML_ANY_SCALAR_STYLE;
       yaml_char_t *value_chars;
-      char *newline;
       if (RSTRING_LEN(value) == 0) {
         /* If the String is empty, it may be reloaded as a nil instead of an
          * empty string, to avoid that place a quoted string instead */
         style = YAML_SINGLE_QUOTED_SCALAR_STYLE;
-      } else if ((newline = strchr(RSTRING_PTR(value), '\n')) != NULL
-                 && newline < (RSTRING_PTR(value) + RSTRING_LEN(value) - 1)) {
-        /* match \n except blank line at the end of string
-         * https://github.com/ruby/psych/blob/v3.1.0/lib/psych/visitors/yaml_tree.rb#L299 */
-        style = YAML_LITERAL_SCALAR_STYLE;
-      } else if (!isalnum(RSTRING_PTR(value)[0])) {
+      }
+      else if (!isalnum(RSTRING_PTR(value)[0])) {
         /* Easy mimic of https://github.com/ruby/psych/blob/v3.1.0/lib/psych/visitors/yaml_tree.rb#L307-L308 */
         style = YAML_DOUBLE_QUOTED_SCALAR_STYLE;
       }

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -228,12 +228,6 @@ assert('YAML dump double quote') do
   assert_equal expected, actual
 end
 
-assert('YAML dump single quote') do
-  expected = %Q[---\nfoo: '{"bar": 1}'\n]
-  actual = YAML.dump(YAML.load(expected))
-  assert_equal expected, actual
-end
-
 assert('YAML dump multi line') do
   expected = %Q[---\na: |\n  b\n  c\n]
   actual = YAML.dump(YAML.load(expected))

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -227,15 +227,3 @@ assert('YAML dump double quote') do
   actual = YAML.dump(YAML.load(expected))
   assert_equal expected, actual
 end
-
-assert('YAML dump multi line') do
-  expected = %Q[---\na: |\n  b\n  c\n]
-  actual = YAML.dump(YAML.load(expected))
-  assert_equal expected, actual
-end
-
-assert('YAML dump single line with newline at the end') do
-  expected = %Q[---\na: 'b\n\n  '\n]
-  actual = YAML.dump(YAML.load(expected))
-  assert_equal expected, actual
-end


### PR DESCRIPTION
## 概要

テストがエラーになるので、追加された機能、およびテストを revert します。

```
Fail: YAML dump single line with newline at the end (mrbgems: mruby-yaml)
 - Assertion[1]
    Expected: "---\na: 'b\n\n  '\n"
      Actual: "---\na: 'b\n\n'\n"
```
https://ci-next.pepabo.com/fukuoka-admin/mruby-sni/168